### PR TITLE
Reproducer for https://github.com/gradle/gradle/issues/37123

### DIFF
--- a/gradle/build-logic/src/main/kotlin/MergeDetektFeature.kt
+++ b/gradle/build-logic/src/main/kotlin/MergeDetektFeature.kt
@@ -26,7 +26,6 @@ abstract class MergeDetektFeature : Plugin<Project>, ProjectFeatureBinding {
         builder.bindProjectFeature("mergeDetekt", ApplyAction::class)
             // https://github.com/gradle/gradle/issues/36755
             .withUnsafeDefinition()
-            .withUnsafeApplyAction()
     }
 
     abstract class ApplyAction : ProjectFeatureApplyAction<MergeDetektDefinition, BuildModel.None, AggregationDefinition> {


### PR DESCRIPTION
DCL: Safe Action with unsafe Definition requires withUnsafeApplyAction

https://github.com/gradle/gradle/issues/37123